### PR TITLE
1.7.4 support, arrow logger and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ A Fabric-Carpet-like mod for old Minecraft versions
 * Type: `boolean`
 * Default: `true`
 
+`fasterItemFrameMaps`
+* Speeds up the time it takes to send map data packets
+* Only affects item frame maps
+* Type: `boolean`
+* Default: `false`
+
 `fillLimit`
 * Volume limit of the fill/clone commands
 * Type: `int`

--- a/src/main/java/net/nullspace_mc/tapestry/loggers/helpers/ProjectileLoggerHelper.java
+++ b/src/main/java/net/nullspace_mc/tapestry/loggers/helpers/ProjectileLoggerHelper.java
@@ -1,5 +1,6 @@
 package net.nullspace_mc.tapestry.loggers.helpers;
 
+import com.google.common.collect.Lists;
 import net.minecraft.text.Formatting;
 import net.minecraft.text.HoverEvent;
 import net.minecraft.text.LiteralText;
@@ -8,9 +9,9 @@ import net.minecraft.util.math.Vec3d;
 import net.nullspace_mc.tapestry.loggers.LoggerRegistry;
 import net.nullspace_mc.tapestry.loggers.ProjectileLogger;
 
-import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class ProjectileLoggerHelper {
 
@@ -23,7 +24,7 @@ public class ProjectileLoggerHelper {
     }
 
     public void tick(double x, double y, double z, double motionX, double motionY, double motionZ) {
-        if (logger.getPlayersSubscribed().size() < 1) return;
+        if (logger.getPlayersSubscribed().isEmpty()) return;
         positions.add(Vec3d.of(x, y, z));
         motions.add(Vec3d.of(motionX, motionY, motionZ));
     }
@@ -40,37 +41,42 @@ public class ProjectileLoggerHelper {
             brief.add(formatBrief(i, pos.x, pos.y, pos.z, mot.x, mot.y, mot.z));
         }
         full.add(new LiteralText(" "));
-
-        Text t = new LiteralText("");
-        brief.forEach(t::append);
-        logger.log(t, "brief");
         full.forEach(line -> logger.log(line, "full"));
+
+        List<Text> finalBrief = Lists.partition(brief, 128) /* Splits the message into smaller chunks */
+                .stream()
+                .map(subList -> subList.stream().reduce(new LiteralText(""), Text::append))
+                .collect(Collectors.toList());
+        finalBrief.forEach(text -> logger.log(text, "brief"));
 
         positions.clear();
         motions.clear();
     }
 
     public Text formatFull(int tick, double x, double y, double z, double vx, double vy, double vz) {
-        DecimalFormat df = new DecimalFormat("#.#");
         Text t = new LiteralText("[Tick " + tick + "] ");
         t.setStyle(t.getStyle().setColor(Formatting.GRAY));
         Text t2 = new LiteralText(
-                String.format("pos[ %s, %s, %s ] mot[ %s, %s, %s ]",
-                        df.format(x), df.format(y), df.format(z),
-                        df.format(vx), df.format(vy), df.format(vz)));
+                String.format("pos[ %.1f, %.1f, %.1f ] mot[ %.1f, %.1f, %.1f ]",
+                        x, y, z,
+                        vx, vy, vz));
         t2.setStyle(t2.getStyle().setColor(Formatting.RESET));
         t.append(t2);
         return t;
     }
 
     public Text formatBrief(int tick, double x, double y, double z, double vx, double vy, double vz) {
-        DecimalFormat df = new DecimalFormat("#.########");
         Text t = new LiteralText("x ");
         Text t2 = new LiteralText(
-                String.format("Tick: %s\n-----\nx: %s\ny: %s\nz: %s\n-----\nmx: %s\nmy: %s\nmz: %s", tick,
-                        df.format(x), df.format(y), df.format(z),
-                        df.format(vx), df.format(vy), df.format(vz)));
+                String.format("Tick: %s\n-----\nx: %.8f\ny: %.8f\nz: %.8f\n-----\nmx: %.8f\nmy: %.8f\nmz: %.8f",
+                        tick,
+                        x, y, z,
+                        vx, vy, vz));
         t.setStyle(t.getStyle().setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, t2)));
         return t;
+    }
+
+    public List<Vec3d> getPositions() {
+        return this.positions;
     }
 }

--- a/src/main/java/net/nullspace_mc/tapestry/loggers/helpers/TNTLoggerHelper.java
+++ b/src/main/java/net/nullspace_mc/tapestry/loggers/helpers/TNTLoggerHelper.java
@@ -6,8 +6,6 @@ import net.minecraft.text.Text;
 import net.nullspace_mc.tapestry.loggers.LoggerRegistry;
 import net.nullspace_mc.tapestry.loggers.TNTLogger;
 
-import java.text.DecimalFormat;
-
 public class TNTLoggerHelper {
 
     private final TNTLogger logger;
@@ -32,15 +30,14 @@ public class TNTLoggerHelper {
     }
 
     public Text format(double px, double py, double pz, double vx, double vy, double vz, double ex, double ey, double ez) {
-        DecimalFormat df = new DecimalFormat("#.#");
         Text t = new LiteralText(
-                String.format("P [ %s, %s, %s ] [ %s, %s, %s ] ",
-                        df.format(px), df.format(py), df.format(pz),
-                        df.format(vx), df.format(vy), df.format(vz)));
+                String.format("P [ %.1f, %.1f, %.1f ] [ %.1f, %.1f, %.1f ] ",
+                        px, py, pz,
+                        vx, vy, vz));
         t.setStyle(t.getStyle().setColor(Formatting.GREEN));
         Text t2 = new LiteralText(
-                String.format("E [ %s, %s, %s ]",
-                        df.format(ex), df.format(ey), df.format(ez)));
+                String.format("E [ %.1f, %.1f, %.1f ]",
+                        ex, ey, ez));
         t2.setStyle(t2.getStyle().setColor(Formatting.RED));
         t.append(t2);
         return t;

--- a/src/main/java/net/nullspace_mc/tapestry/mixin/feature/fasteritemframemaps/EntityTrackerEntryMixin.java
+++ b/src/main/java/net/nullspace_mc/tapestry/mixin/feature/fasteritemframemaps/EntityTrackerEntryMixin.java
@@ -1,0 +1,29 @@
+package net.nullspace_mc.tapestry.mixin.feature.fasteritemframemaps;
+
+import net.minecraft.server.entity.EntityTrackerEntry;
+import net.nullspace_mc.tapestry.settings.Settings;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(EntityTrackerEntry.class)
+public class EntityTrackerEntryMixin {
+
+    @Shadow public int ticks;
+
+    @Redirect(
+            method = "notifyNewLocation",
+            at = @At(
+                    value = "FIELD",
+                    target = "Lnet/minecraft/server/entity/EntityTrackerEntry;ticks:I",
+                    ordinal = 1
+            )
+    )
+    private int setTicks(EntityTrackerEntry instance) {
+        if (Settings.fasterItemFrameMaps) {
+            return 0;
+        }
+        return this.ticks;
+    }
+}

--- a/src/main/java/net/nullspace_mc/tapestry/mixin/loggers/projectiles/ArrowEntityMixin.java
+++ b/src/main/java/net/nullspace_mc/tapestry/mixin/loggers/projectiles/ArrowEntityMixin.java
@@ -1,0 +1,43 @@
+package net.nullspace_mc.tapestry.mixin.loggers.projectiles;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.living.LivingEntity;
+import net.minecraft.entity.projectile.ArrowEntity;
+import net.minecraft.world.World;
+import net.nullspace_mc.tapestry.loggers.helpers.ProjectileLoggerHelper;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ArrowEntity.class)
+public abstract class ArrowEntityMixin extends Entity {
+
+    @Unique ProjectileLoggerHelper helper;
+
+    @Shadow private boolean inGround;
+
+    public ArrowEntityMixin(World world) {
+        super(world);
+    }
+
+    @Inject(method = "<init>(Lnet/minecraft/world/World;Lnet/minecraft/entity/living/LivingEntity;F)V", at = @At("RETURN"))
+    private void addLogger(World world, LivingEntity shooter, float speed, CallbackInfo ci) {
+        helper = new ProjectileLoggerHelper();
+    }
+
+    @Inject(method = "tick", at = @At("HEAD"))
+    private void tickCheck(CallbackInfo ci) {
+        if (helper == null) {
+            return;
+        }
+
+        if (!inGround) {
+            helper.tick(this.x, this.y, this.z, this.velocityX, this.velocityY, this.velocityZ);
+        } else if (!helper.getPositions().isEmpty()) {
+            helper.onFinish();
+        }
+    }
+}

--- a/src/main/java/net/nullspace_mc/tapestry/settings/Settings.java
+++ b/src/main/java/net/nullspace_mc/tapestry/settings/Settings.java
@@ -118,6 +118,13 @@ public class Settings {
     public static boolean explosionBlockBreaking = true;
 
     @Rule(
+            desc = "Speeds up the time it takes to send map data packets",
+            extra = "Only affects item frame maps",
+            category = {RuleCategory.FEATURE}
+    )
+    public static boolean fasterItemFrameMaps = false;
+
+    @Rule(
             desc = "Volume limit of the fill/clone commands",
             category = RuleCategory.CREATIVE,
             options = {"32768", "250000", "1000000"},

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -26,7 +26,7 @@
 	],
 
 	"depends": {
-		"minecraft": "1.7.2",
+		"minecraft": ">=1.7.2 <=1.7.4",
 		"osl-entrypoints": ">=0.2.0",
 		"osl-lifecycle-events": ">=0.4.0",
 		"osl-networking": ">=0.4.0"

--- a/src/main/resources/tapestry.mixins.json
+++ b/src/main/resources/tapestry.mixins.json
@@ -20,6 +20,7 @@
     "feature.clonecommand.ServerWorldMixin",
     "feature.creativenoclip.ServerPlayNetworkHandlerMixin",
     "feature.explosionblockbreaking.ExplosionMixin",
+    "feature.fasteritemframemaps.EntityTrackerEntryMixin",
     "feature.fillorientationfix.ChestBlockMixin",
     "feature.fillorientationfix.ChunkMixin",
     "feature.fillorientationfix.DispenserBlockMixin",

--- a/src/main/resources/tapestry.mixins.json
+++ b/src/main/resources/tapestry.mixins.json
@@ -48,6 +48,7 @@
     "feature.tcpnodelay.RemoteChannelHandlerMixin",
     "loggers.mobcap.NaturalSpawnerAccessor",
     "loggers.mobcap.ServerWorldAccessor",
+    "loggers.projectiles.ArrowEntityMixin",
     "loggers.projectiles.ThrownEntityMixin",
     "loggers.tnt.PrimedTntEntityMixin",
     "tick.MinecraftServerMixin"


### PR DESCRIPTION
- Mod can now be loaded in MC 1.7.2-1.7.4. Might work with 1.7.5 but I haven't tested.
- Added arrow logging to the projectile logger.
- Improved TNT and projectile logger code.
- New rule: `fasterItemFrameMaps`: speeds up map packets for item frames.